### PR TITLE
Fix required field of issue-numbers

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -3,7 +3,7 @@ description: say Hello World
 inputs:
   issue-numbers:
     description: a number of issue or pull request, or an array of numbers of issues or pull requests in JSON format
-    required: true
+    required: false
   context:
     description: infer an issue or pull request(s) from the context
     required: true


### PR DESCRIPTION
Actually, not required:
https://github.com/int128/issues-action/blob/ed82bc5b4d3c418c494b40bad676bac7d621e992/src/main.ts#L6
<!-- issues-action/ts/test -->
----
:octocat: https://github.com/int128/issues-action/actions/runs/5400095301
<!-- issues-action/ts/test -->
